### PR TITLE
Scroll thumbnail to match currentMediaIndex

### DIFF
--- a/app/src/main/java/com/arturo254/opentune/ui/player/Thumbnail.kt
+++ b/app/src/main/java/com/arturo254/opentune/ui/player/Thumbnail.kt
@@ -101,6 +101,12 @@ fun Thumbnail(
     val mediaItems = listOfNotNull(previousMediaMetadata, currentMediaItem, nextMediaMetadata)
     val currentMediaIndex = mediaItems.indexOf(currentMediaItem)
 
+    LaunchedEffect(currentMediaIndex) {
+        if (currentMediaIndex != -1) {
+            thumbnailLazyGridState.scrollToItem(currentMediaIndex)
+        }
+    }
+
     val snapProvider = remember(thumbnailLazyGridState) {
         SnapLayoutInfoProvider(
             lazyGridState = thumbnailLazyGridState,


### PR DESCRIPTION
This ensures that the player thumbnail matches the current song.

Fixes #440.

@Arturo254  If this is not the correct fix, please close this and make the appropriate fix.