### PR TITLE
feat(ci): add automated debug APK build workflow with Gradle optimizations

### DIFF
--- a/.github/workflows/debugBuild.yml
+++ b/.github/workflows/debugBuild.yml
@@ -1,0 +1,95 @@
+name: Debug Build
+
+concurrency:
+  group: "build"
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      # ── 1. CHECKOUT ────────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      # ── 2. PERMISOS ────────────────────────────────────────────────────────────
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # ── 3. JDK ─────────────────────────────────────────────────────────────────
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      # ── 4. GRADLE CACHE ────────────────────────────────────────────────────────
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-read-only: false
+
+      # ── 5. SIGNING ─────────────────────────────────────────────────────────────
+      #   - Si DEBUG_KEYSTORE_BASE64 existe → lo decodifica y lo usa (firma consistente)
+      #   - Si no existe               → genera uno aleatorio con aviso (firma efímera)
+      # En ambos casos termina con los env vars de firma configurados.
+      - name: Setup debug keystore & signing env vars
+        env:
+          KEYSTORE_SECRET: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          mkdir -p ~/work/_temp/keystore/
+          if [ -n "$KEYSTORE_SECRET" ]; then
+            printf '%s' "$KEYSTORE_SECRET" | base64 -d > "$RUNNER_TEMP/keystore/prerelease.keystore"
+            echo "✅ Keystore cargado desde DEBUG_KEYSTORE_BASE64"
+          else
+            keytool -genkey -v \
+              -keystore "$RUNNER_TEMP/keystore/prerelease.keystore" \
+              -storepass android \
+              -keypass android \
+              -alias androiddebugkey \
+              -keyalg RSA -keysize 2048 -validity 10000 \
+              -dname "C=US, O=Android, CN=Android Debug"
+            echo ""
+            echo "════════════════════════════════════════════════════════"
+            echo "⚠️  DEBUG_KEYSTORE_BASE64 no está configurado."
+            echo "    Este APK usa una firma aleatoria — no podrás instalar"
+            echo "    esta build sobre una anterior sin desinstalarla antes."
+            echo ""
+            echo "    Para fijar esta firma de forma permanente, copia el"
+            echo "    bloque de abajo y añádelo en:"
+            echo "    Settings → Secrets and variables → Actions → [New Repository Secret]"
+            echo "    Nombre del secret: DEBUG_KEYSTORE_BASE64"
+            echo "════════════════════════════════════════════════════════"
+            base64 "$RUNNER_TEMP/keystore/prerelease.keystore"
+            echo "════════════════════════════════════════════════════════"
+          fi
+          echo "MUSIC_DEBUG_KEYSTORE_FILE=$HOME/work/_temp/keystore/prerelease.keystore" >> $GITHUB_ENV
+          echo "MUSIC_DEBUG_SIGNING_STORE_PASSWORD=android" >> $GITHUB_ENV
+          echo "MUSIC_DEBUG_SIGNING_KEY_PASSWORD=android" >> $GITHUB_ENV
+          echo "MUSIC_DEBUG_SIGNING_KEY_ALIAS=androiddebugkey" >> $GITHUB_ENV
+
+      # ── 6. BUILD ───────────────────────────────────────────────────────────────
+      # --build-cache       → reutiliza outputs de tareas cacheadas
+      # --configuration-cache → cachea la fase de configuración de Gradle
+      # --parallel          → ejecuta tareas independientes en paralelo
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug --build-cache --configuration-cache --parallel
+
+      # ── 7. ARTIFACT ────────────────────────────────────────────────────────────
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apk-${{ github.ref_name }}-run${{ github.run_number }}
+          path: "app/build/outputs/apk/debug/*.apk"
+          retention-days: 7

--- a/.github/workflows/debugBuild.yml
+++ b/.github/workflows/debugBuild.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           KEYSTORE_SECRET: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
         run: |
-          mkdir -p ~/work/_temp/keystore/
+          mkdir -p "$RUNNER_TEMP/keystore/"
           if [ -n "$KEYSTORE_SECRET" ]; then
             printf '%s' "$KEYSTORE_SECRET" | base64 -d > "$RUNNER_TEMP/keystore/prerelease.keystore"
             echo "✅ Keystore cargado desde DEBUG_KEYSTORE_BASE64"
@@ -74,7 +74,7 @@ jobs:
             base64 "$RUNNER_TEMP/keystore/prerelease.keystore"
             echo "════════════════════════════════════════════════════════"
           fi
-          echo "MUSIC_DEBUG_KEYSTORE_FILE=$HOME/work/_temp/keystore/prerelease.keystore" >> $GITHUB_ENV
+          echo "MUSIC_DEBUG_KEYSTORE_FILE=$RUNNER_TEMP/keystore/prerelease.keystore" >> $GITHUB_ENV
           echo "MUSIC_DEBUG_SIGNING_STORE_PASSWORD=android" >> $GITHUB_ENV
           echo "MUSIC_DEBUG_SIGNING_KEY_PASSWORD=android" >> $GITHUB_ENV
           echo "MUSIC_DEBUG_SIGNING_KEY_ALIAS=androiddebugkey" >> $GITHUB_ENV

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
             if (System.getenv("MUSIC_DEBUG_SIGNING_STORE_PASSWORD") != null) {
                 storeFile = file(System.getenv("MUSIC_DEBUG_KEYSTORE_FILE"))
                 storePassword = System.getenv("MUSIC_DEBUG_SIGNING_STORE_PASSWORD")
-                keyAlias = "debug"
+                keyAlias = System.getenv("MUSIC_DEBUG_SIGNING_KEY_ALIAS") ?: "androiddebugkey"
                 keyPassword = System.getenv("MUSIC_DEBUG_SIGNING_KEY_PASSWORD")
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,9 +12,31 @@
 # org.gradle.parallel=true
 #Sat Nov 19 15:59:34 CST 2022
 
-org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+# ------------------------------------------------------------
+# Rendimiento Gradle
+# ------------------------------------------------------------
+# Reutiliza salidas de tareas entre builds (local cache).
+org.gradle.caching=true
+
+# Permite ejecución en paralelo cuando aplica (especialmente útil en multi-módulo).
+org.gradle.parallel=true
+
+# Configuration Cache (estable). Acelera la fase de configuración en builds repetidos.
+org.gradle.configuration-cache=true
+# Modo tolerante mientras validas compatibilidad; si prefieres estricto, quita esta línea.
+org.gradle.configuration-cache.problems=warn
+
+# JVM / Kotlin daemon
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-Xmx4g
+
+# ------------------------------------------------------------
+# Android / Kotlin
+# ------------------------------------------------------------
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.unsafe.configuration-cache=true
+
+# Valores dependinetes del codigo (cambiarlos puede requerir ajustes en el código).
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+kotlin.code.style=official


### PR DESCRIPTION

### Summary

This PR introduces a GitHub Actions CI workflow to build debug APKs automatically on every push, signed consistently with a stable key from `DEBUG_KEYSTORE_BASE64`. It also includes Gradle performance optimizations to reduce build times on both CI and local environments.

### Motivation

The project had no automated build pipeline. Developers had to build locally and distribute APKs manually. Adding CI allows any push to automatically produce a downloadable debug artifact, and the consistent signing key means new builds can be installed directly over previous ones without uninstalling, preserving all internal app data and configuration.

### Changes

**`.github/workflows/debugBuild.yml`** *(new file)*

- Triggers on every `push` (excluding `.md` files) and manually via `workflow_dispatch`
- Checkout uses `submodules: recursive` + `fetch-depth: 1` for a fast shallow clone including all submodules
- Signing is fully self-contained in a single step: if `DEBUG_KEYSTORE_BASE64` secret exists it is decoded and used; otherwise a temporary keystore is generated and its base64 payload is printed with step-by-step instructions to save it as a permanent secret for future runs
- Keystore stored in `$RUNNER_TEMP` (standard GitHub Actions runner path)
- Build runs `./gradlew assembleDebug --build-cache --configuration-cache --parallel` to take full advantage of Gradle caching
- Resulting APK is uploaded as a downloadable artifact (`debug-apk-<branch>-run<N>`) with a 7-day retention period

**`app/build.gradle.kts`**

- `signingConfigs.debug` now reads from the correct env vars (`MUSIC_DEBUG_KEYSTORE_FILE`, `MUSIC_DEBUG_SIGNING_STORE_PASSWORD`, `MUSIC_DEBUG_SIGNING_KEY_PASSWORD`)
- `keyAlias` reads from `MUSIC_DEBUG_SIGNING_KEY_ALIAS` env var (defaulting to `androiddebugkey`) instead of being hardcoded to `"debug"`, ensuring it matches the keystore generated by CI

**`gradle.properties`**

- Added `org.gradle.caching=true` (Build Cache)
- Added `org.gradle.parallel=true` (parallel task execution)
- Replaced deprecated `org.gradle.unsafe.configuration-cache=true` with stable `org.gradle.configuration-cache=true` + `org.gradle.configuration-cache.problems=warn`
- Improved `org.gradle.jvmargs`: added `-Dfile.encoding=UTF-8` and `-XX:+UseParallelGC`
- Added `kotlin.code.style=official`


### Related Issues

N/A — new CI infrastructure addition.

