### PR TITLE
fix(android-auto): resolve MediaBrowserService discovery on Android 14+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -150,12 +150,12 @@
             android:name=".playback.MusicService"
             android:exported="true"
             android:foregroundServiceType="mediaPlayback"
-            android:permission="android.permission.BIND_MEDIA_BROWSER_SERVICE"
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
                 <action android:name="androidx.media3.session.MediaLibraryService" />
                 <action android:name="android.media.browse.MediaBrowserService" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
 
@@ -180,6 +180,9 @@
         <meta-data
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />
+        <meta-data
+            android:name="androidx.car.app.TintableAttributionIcon"
+            android:resource="@drawable/status" />
 
         <activity
             android:name=".DebugActivity"


### PR DESCRIPTION
AndroidManifest.xml Changes
1. BIND_MEDIA_BROWSER_SERVICE Permission Removal
Location: MusicService declaration

Why: Starting with Android 14 (API 34), the BIND_MEDIA_BROWSER_SERVICE permission on the service declaration conflicts with Media3's MediaLibraryService implementation. Media3 handles the permission binding internally through its session framework, making the explicit permission redundant and causing discovery failures on newer Android versions.

Reference: [Android 14 Behavior Changes - Media](https://developer.android.com/about/versions/14/behavior-changes-all#media)

2. DEFAULT Category Addition
Location: MediaBrowserService intent-filter

Why: Android Auto's MediaBrowserService discovery mechanism requires the android.intent.category.DEFAULT category to be present in the service's intent-filter. Without it, the Android Auto host app cannot bind to the service during the discovery phase, resulting in "App doesn't support Android Auto" or similar connection errors.

Technical Detail: The MediaBrowser framework in Android Auto uses implicit intents with CATEGORY_DEFAULT when searching for media services. Missing this category causes the PackageManager query to exclude OpenTune from available media apps.

3. TintableAttributionIcon Metadata
Location: Application-level meta-data

Why: Provides a branded icon for Android Auto's media browser UI that automatically tints to match the car's color scheme. The status drawable is already vector-based, making it ideal for dynamic tinting in automotive contexts.

Note: This metadata is consumed by the AndroidX Car App library and the Android Auto Host to display the app icon in the media app's browse hierarchy.