### PR TITLE
fix: show search history immediately without waiting for network

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/viewmodels/OnlineSearchSuggestionViewModel.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/viewmodels/OnlineSearchSuggestionViewModel.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arturo254.opentune.innertube.YouTube
+import com.arturo254.opentune.innertube.models.SearchSuggestions
 import com.arturo254.opentune.innertube.models.YTItem
 import com.arturo254.opentune.innertube.models.filterExplicit
 import com.arturo254.opentune.innertube.models.filterVideo
@@ -27,6 +28,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -44,43 +47,52 @@ constructor(
     val viewState = _viewState.asStateFlow()
 
     init {
+        // History flow: updates immediately from DB
         viewModelScope.launch {
             query
                 .flatMapLatest { query ->
                     if (query.isEmpty()) {
                         database.searchHistory().map { history ->
-                            SearchSuggestionViewState(
-                                history = history,
-                            )
+                            SearchSuggestionViewState(history = history)
                         }
                     } else {
-                        val result = YouTube.searchSuggestions(query).getOrNull()
                         database
                             .searchHistory(query)
                             .map { it.take(3) }
                             .map { history ->
-                                SearchSuggestionViewState(
-                                    history = history,
-                                    suggestions =
-                                    result
-                                        ?.queries
-                                        ?.filter { query ->
-                                            history.none { it.query == query }
-                                        }.orEmpty(),
-                                    items = result
-                                        ?.recommendedItems
-                                        ?.filterExplicit(
-                                            context.dataStore.get(
-                                                HideExplicitKey,
-                                                false,
-                                            ),
-                                        )
-                                        ?.filterVideo(context.dataStore.get(HideVideoKey, false)).orEmpty(),
-                                )
+                                SearchSuggestionViewState(history = history)
                             }
                     }
                 }.collect {
                     _viewState.value = it
+                }
+        }
+
+        // Suggestions flow: fetches from network independently
+        viewModelScope.launch {
+            query
+                .flatMapLatest { query ->
+                    if (query.isEmpty()) {
+                        flowOf<SearchSuggestions?>(null)
+                    } else {
+                        flow<SearchSuggestions?> {
+                            emit(null) // clear stale suggestions immediately
+                            emit(YouTube.searchSuggestions(query).getOrNull())
+                        }
+                    }
+                }.collect { result ->
+                    val history = _viewState.value.history
+                    _viewState.value = _viewState.value.copy(
+                        suggestions = result
+                            ?.queries
+                            ?.filter { s -> history.none { it.query == s } }
+                            .orEmpty(),
+                        items = result
+                            ?.recommendedItems
+                            ?.filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                            ?.filterVideo(context.dataStore.get(HideVideoKey, false))
+                            .orEmpty(),
+                    )
                 }
         }
     }


### PR DESCRIPTION
Decoupled the DB history flow from the network suggestions flow in `OnlineSearchSuggestionViewModel`. Previously, the ViewModel awaited the YouTube suggestions response before emitting history, causing the history to not appear while the network was slow or unavailable.

**Key Changes:**

- **History coroutine:** Queries `searchHistory` from the local Room database and emits results immediately, independent of network state.
- **Suggestions coroutine:** Fetches `YouTube.searchSuggestions` in a separate coroutine, emitting `null` first to clear stale suggestions, then updating the state when the response arrives.
- **Type safety:** Explicitly typed `flow<SearchSuggestions?>` and `flowOf<SearchSuggestions?>` to resolve Kotlin type inference issues with nullable emissions.