### PR TITLE
Update Items.kt

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/Items.kt
@@ -80,7 +80,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.zIndex
 import androidx.media3.common.MediaItem
@@ -149,7 +148,9 @@ inline fun ListItem(
         Box(Modifier.padding(6.dp), contentAlignment = Alignment.Center) { thumbnailContent() }
         Column(Modifier.weight(1f).padding(horizontal = 6.dp)) {
             Text(
-                text = title, fontSize = 14.sp, fontWeight = FontWeight.Bold,
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
                 maxLines = 1, overflow = TextOverflow.Ellipsis
             )
             if (subtitle != null) Row(verticalAlignment = Alignment.CenterVertically) { subtitle() }
@@ -174,7 +175,7 @@ fun ListItem(
     subtitle = {
         badges()
         if (!subtitle.isNullOrEmpty()) {
-            Text(text = subtitle, color = MaterialTheme.colorScheme.secondary, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(text = subtitle, color = MaterialTheme.colorScheme.secondary, style = MaterialTheme.typography.bodySmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     },
     thumbnailContent = thumbnailContent,


### PR DESCRIPTION
fix(ui): replace hardcoded 14sp/12sp font sizes with MD3 typography tokens

ListItem is the most reused component in the app, used by every song,
album, and artist row. Its title used fontSize=14sp and subtitle used
fontSize=12sp, both bypassing the MD3 typography scale and the user's
system font size accessibility setting. Replaced with
typography.bodyLarge for title and typography.bodySmall for subtitle.
Removed the now-unused sp import.