### PR TITLE
Update ThumbnailCornerRadiusSelector.kt

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/ThumbnailCornerRadiusSelector.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/ThumbnailCornerRadiusSelector.kt
@@ -54,8 +54,9 @@ fun ThumbnailCornerRadiusSelectorButton(
             .fillMaxWidth()
             .heightIn(min = 56.dp)
             .clip(RoundedCornerShape(26.dp)),
-        shadowElevation = 10.dp,
-        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 2.dp,
+        shadowElevation = 0.dp,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
         onClick = { showDialog = true }
     ) {
         Row(


### PR DESCRIPTION
fix(md3): replace shadowElevation=10dp with MD3 tonalElevation system

The Surface was using a 10dp pixel drop shadow, which is a Material
Design 2 pattern explicitly replaced in MD3. Switched to tonalElevation=2dp
which uses the theme color tint system instead of shadows. Also corrected
the container color from surface to surfaceContainerLow, matching the
MD3 color role used by all other settings preference items in the app.