### PR TITLE
Update NavigationTile.kt

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/NavigationTile.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/NavigationTile.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -25,6 +26,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -38,20 +42,22 @@ fun NavigationTile(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
-        modifier = modifier.padding(6.dp),
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .semantics { role = Role.Button }
+            .padding(6.dp),
     ) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier =
-            Modifier
+            modifier = Modifier
                 .size(56.dp)
                 .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceContainer)
-                .clickable(onClick = onClick),
+                .background(MaterialTheme.colorScheme.surfaceContainer),
         ) {
             Icon(
                 painter = painterResource(icon),
-                contentDescription = null,
+                contentDescription = title,
             )
         }
 


### PR DESCRIPTION
fix(ui): expand NavigationTile tap target to full tile and add accessibility semantics

The clickable modifier was only applied to the 56dp icon circle,
making the text label below it non-interactive. Moved clickable to
the parent Column so the entire tile (icon + label) registers touch.
Added semantics { role = Role.Button } for TalkBack screen reader
support. Also fixed contentDescription from null to the tile title
so TalkBack announces the button name correctly.