### PR TITLE
Update Player.kt fix(player): resolve queue sheet not being tappable or visible when collapsed

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
@@ -548,10 +548,10 @@ fun BottomSheetPlayer(
     val dismissedBound = dynamicQueuePeekHeight + WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
     val queueSheetState = rememberBottomSheetState(
-        dismissedBound = dismissedBound,
+        dismissedBound = 0.dp,
         expandedBound = state.expandedBound,
         collapsedBound = dismissedBound,
-        initialAnchor = 0
+        initialAnchor = COLLAPSED_ANCHOR
     )
 
     val lyricsSheetState = rememberBottomSheetState(


### PR DESCRIPTION
fix(player): queue collapsed bar not visible or tappable

collapsedBound was set equal to dismissedBound, causing the
BottomSheet offset calculation to push the entire queue bar
off-screen. The collapsed queue pill (Queue / Lyrics buttons)
was rendered but never visible or reachable by touch.

Fix: set dismissedBound to 0.dp so the sheet has a true hidden
state, use the original dismissedBound value as collapsedBound
so the queue bar renders at the correct height, and start at
COLLAPSED_ANCHOR so the bar is immediately visible when the
player opens.