### PR TITLE
I18n/hindi strings expand

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
@@ -548,10 +548,10 @@ fun BottomSheetPlayer(
     val dismissedBound = dynamicQueuePeekHeight + WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
     val queueSheetState = rememberBottomSheetState(
-        dismissedBound = dismissedBound,
+        dismissedBound = 0.dp,
         expandedBound = state.expandedBound,
         collapsedBound = dismissedBound,
-        initialAnchor = 0
+        initialAnchor = COLLAPSED_ANCHOR
     )
 
     val lyricsSheetState = rememberBottomSheetState(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,818 +1,216 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Upstream InnerTune strings --><!-- Do not add new features here --><!-- Try to re-use strings here, but be careful on its usage e.g. verb vs noun --><!-- "InnerTune" is replaced with "OpenTune" --><!-- Translators: Do not modify this file for translations, use InnerTune's Weblate instead. --><resources>
+<!-- Hindi (हिन्दी) translation for OpenTune -->
+<!-- Locale: values-hi -->
+<!-- Contributor: gorupa (https://github.com/gorupa) -->
+<resources>
     <!-- Bottom navigation -->
-    <string name="home">Home</string>
-    <string name="songs">Songs</string>
-    <string name="artists">Artists</string>
-    <string name="albums">Albums</string>
-    <string name="playlists">Playlists</string>
-    <!-- Top bar -->
-    <plurals name="n_selected">
-        <item quantity="other">%d selected</item>
-    </plurals>
-    <!-- Home -->
-    <string name="history">History</string>
-    <string name="stats">Stats</string>
-    <string name="mood_and_genres">Mood &amp; Genres</string>
-    <string name="account">Account</string>
-    <string name="quick_picks">Quick picks</string>
-    <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="speed_dial">Speed dial</string>
-    <string name="speed_dial_random">Play random speed dial song</string>
-    <string name="forgotten_favorites">Forgotten favorites</string>
-    <string name="keep_listening">Keep listening</string>
-    <string name="your_youtube_playlists">Your YouTube playlists</string>
-    <string name="similar_to">Similar to</string>
-    <string name="new_release_albums">New release albums</string>
-    <string name="select_playlist_to_sync">Select Playlist To Sync</string>
-    <string name="integration">Integration</string>
-    <string name="integrations">Integrations</string>
-    <string name="internal_subcategory_settings">Internal &amp; subcategory settings</string>
-    <string name="search_try_different">Try a different search term</string>
-    <!-- History -->
-    <string name="today">Today</string>
-    <string name="yesterday">Yesterday</string>
-    <string name="this_week">This week</string>
-    <string name="last_week">Last week</string>
-    <!-- Stats -->
-    <string name="most_played_songs">Most played songs</string>
-    <string name="most_played_artists">Most played artists</string>
-    <string name="most_played_albums">Most played albums</string>
-    <!-- Search -->
-    <string name="search">Search</string>
-    <string name="search_yt_music">Search YouTube Music…</string>
-    <string name="search_library">Search library…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
-    <string name="filter_downloaded_full">Downloaded (Full)</string>
-    <string name="filter_all">All</string>
-    <string name="filter_songs">Songs</string>
-    <string name="filter_videos">Videos</string>
-    <string name="filter_albums">Albums</string>
-    <string name="filter_artists">Artists</string>
-    <string name="filter_playlists">Playlists</string>
-    <string name="filter_community_playlists">Community playlists</string>
-    <string name="filter_featured_playlists">Featured playlists</string>
-    <string name="filter_bookmarked">Bookmarked</string>
-    <string name="no_results_found">No results found</string>
-    <string name="top_results">Top Results</string>
+    <string name="home">होम</string>
+    <string name="songs">गाने</string>
+    <string name="artists">कलाकार</string>
+    <string name="albums">एल्बम</string>
+    <string name="playlists">प्लेलिस्ट</string>
+
+    <!-- Common actions -->
+    <string name="search">खोजें</string>
+    <string name="play">चलाएं</string>
+    <string name="shuffle">शफ़ल</string>
+    <string name="history">इतिहास</string>
+    <string name="settings">सेटिंग</string>
+    <string name="about">के बारे में</string>
+    <string name="lyrics">गीत के बोल</string>
+    <string name="download">डाउनलोड</string>
+    <string name="share">साझा करें</string>
+    <string name="edit">संपादित करें</string>
+    <string name="delete">हटाएं</string>
+    <string name="save">सहेजें</string>
+    <string name="retry">पुन: प्रयास करें</string>
+    <string name="radio">रेडियो</string>
+    <string name="next">अगला</string>
+    <string name="account">खाता</string>
+    <string name="queue">कतार</string>
+    <string name="stats">आँकड़े</string>
+    <string name="mood_and_genres">मूड और शैलियाँ</string>
+
     <!-- Library -->
-    <string name="library_song_empty">Library songs will show up here</string>
-    <string name="library_artist_empty">Library artists will show up here</string>
-    <string name="library_album_empty">Library albums will show up here</string>
-    <string name="library_playlist_empty">Your playlists will show up here</string>
-    <!-- Artist screen -->
-    <string name="from_your_library">From your library</string>
-    <!-- Album screen -->
-    <string name="other_versions">Other versions</string>
+    <string name="library_song_empty">आपके गाने यहाँ दिखेंगे</string>
+    <string name="library_artist_empty">आपके कलाकार यहाँ दिखेंगे</string>
+    <string name="library_album_empty">आपके एल्बम यहाँ दिखेंगे</string>
+    <string name="library_playlist_empty">आपकी प्लेलिस्ट यहाँ दिखेंगी</string>
+
     <!-- Playlist -->
-    <string name="liked_songs">Liked songs</string>
-    <string name="downloaded_songs">Downloaded songs</string>
-    <string name="playlist_is_empty">The playlist is empty</string>
-    <string name="remove_download_playlist_confirm">Do you really want to remove all \"%s\" playlist songs from the Downloaded Songs storage?</string>
-    <string name="delete_playlist_confirm">Do you really want to delete the playlist \"%s\"?</string>
-    <string name="change_playlist_cover">Change playlist cover</string>
-    <string name="remove_playlist_cover">Remove Cover</string>
-    <!-- Button -->
-    <string name="retry">Retry</string>
-    <string name="radio">Radio</string>
-    <string name="shuffle">Shuffle</string>
-    <string name="music_recognition">Music Recognition</string>
-    <string name="reset">Reset</string>
-    <!-- Menu -->
-    <string name="details">Details</string>
-    <string name="edit">Edit</string>
-    <string name="start_radio">Start radio</string>
-    <string name="play">Play</string>
-    <string name="play_next">Play next</string>
-    <string name="add_to_queue">Add to queue</string>
-    <string name="add_to_library">Add to library</string>
-    <string name="add_all_to_library">Add all to library</string>
-    <string name="remove_from_library">Remove from library</string>
-    <string name="remove_all_from_library">Remove all from library</string>
-    <string name="action_download">Download</string>
-    <string name="downloading">Downloading</string>
-    <string name="remove_download">Remove download</string>
-    <string name="import_playlist">Import playlist</string>
-    <string name="import_failed">Import failed</string>
-    <string name="update_button">Update</string>
-    <string name="add_to_playlist">Add to playlist</string>
-    <string name="pin_to_speed_dial">Pin to speed dial</string>
-    <string name="remove_from_speed_dial">Remove from speed dial</string>
-    <string name="view_artist">View artist</string>
-    <string name="view_album">View album</string>
-    <string name="view_all">View all</string>
-    <string name="more">more</string>
-    <string name="refetch">Refetch</string>
-    <string name="share">Share</string>
-    <string name="delete">Delete</string>
-    <string name="together_participants">Participants</string>
-    <string name="together_connected_count">%1$d connected</string>
-    <string name="together_role_host">Host</string>
-    <string name="together_role_guest">Guest</string>
-    <string name="together_pending_approval">Pending approval</string>
-    <string name="together_waiting_approval">Waiting Approval</string>
-    <string name="together_host_left_session">Host Leaved Sessions</string>
-    <string name="together_kick">Kick</string>
-    <string name="together_ban">Ban</string>
-    <string name="together_kick_confirm">Kick %1$s?</string>
-    <string name="together_ban_confirm">Ban %1$s?</string>
-    <string name="together_requesting_song_change">Requesting host to change the song\u2026</string>
-    <string name="together_song_change_failed">Song change not applied. Please try again.</string>
-    <string name="remove_from_history">Remove from history</string>
-    <string name="remove_from_playlist">Remove from playlist</string>
-    <string name="remove_from_queue">Remove from queue</string>
-    <string name="search_online">Search online</string>
-    <string name="action_sync">Sync</string>
-    <string name="advanced">Advanced</string>
-    <string name="tempo_and_pitch">Tempo and Pitch</string>
-    <string name="tempo">Tempo</string>
-    <string name="pitch">Pitch</string>
+    <string name="liked_songs">पसंदीदा गाने</string>
+    <string name="downloaded_songs">डाउनलोड किए गए गाने</string>
+    <string name="playlist_is_empty">प्लेलिस्ट खाली है</string>
+    <string name="add_to_playlist">प्लेलिस्ट में जोड़ें</string>
+    <string name="add_to_queue">कतार में जोड़ें</string>
+    <string name="play_next">अगला चलाएं</string>
+    <string name="start_radio">रेडियो शुरू करें</string>
+    <string name="import_playlist">प्लेलिस्ट आयात करें</string>
+
+    <!-- Search -->
+    <string name="no_results_found">कोई परिणाम नहीं मिला</string>
+    <string name="search_yt_music">YouTube Music खोजें…</string>
+    <string name="search_library">लाइब्रेरी खोजें…</string>
+    <string name="filter_songs">गाने</string>
+    <string name="filter_artists">कलाकार</string>
+    <string name="filter_albums">एल्बम</string>
+    <string name="filter_playlists">प्लेलिस्ट</string>
+    <string name="filter_liked">पसंदीदा</string>
+    <string name="filter_downloaded">डाउनलोड किए गए</string>
+
+    <!-- History -->
+    <string name="today">आज</string>
+    <string name="yesterday">कल</string>
+    <string name="this_week">इस सप्ताह</string>
+    <string name="last_week">पिछले सप्ताह</string>
+
+    <!-- Menu actions -->
+    <string name="add_to_library">लाइब्रेरी में जोड़ें</string>
+    <string name="remove_from_library">लाइब्रेरी से हटाएं</string>
+    <string name="action_download">डाउनलोड</string>
+    <string name="remove_download">डाउनलोड हटाएं</string>
+    <string name="downloading">डाउनलोड हो रहा है</string>
+    <string name="details">विवरण</string>
+
+    <!-- About screen -->
+    <string name="contributors">योगदानकर्ता</string>
+    <string name="social_links">सामाजिक नेटवर्क</string>
+    <string name="view_license">GitHub पर पूर्ण लाइसेंस देखें</string>
+
+    <!-- Lyrics -->
+    <string name="lyrics_not_found">गीत के बोल नहीं मिले</string>
+
+    <!-- Player -->
+    <string name="quick_picks">त्वरित पसंद</string>
+    <string name="keep_listening">सुनते रहें</string>
+    <string name="new_release_albums">नए एल्बम</string>
+
+    <!-- Player controls -->
+    <string name="music_player">म्यूज़िक प्लेयर</string>
+    <string name="player">प्लेयर</string>
+    <string name="volume">वॉल्यूम</string>
+    <string name="pitch">पिच</string>
+    <string name="tempo_and_pitch">टेम्पो और पिच</string>
     <string name="pitch_mode_semitones_short">st</string>
     <string name="pitch_mode_multiplier_short">x</string>
-    <!-- Sort menu -->
-    <string name="sort_by_create_date">Date added</string>
-    <string name="sort_by_name">Name</string>
-    <string name="sort_by_artist">Artist</string>
-    <string name="sort_by_year">Year</string>
-    <string name="sort_by_song_count">Song count</string>
-    <string name="sort_by_length">Length</string>
-    <string name="sort_by_play_time">Play time</string>
-    <string name="sort_by_custom">Custom order</string>
-    <!-- Dialog -->
-    <string name="media_id">Media id</string>
-    <string name="mime_type">MIME type</string>
-    <string name="codecs">Codecs</string>
-    <string name="bitrate">Bitrate</string>
-    <string name="sample_rate">Sample rate</string>
-    <string name="loudness">Loudness</string>
-    <string name="volume">Volume</string>
-    <string name="file_size">File size</string>
-    <string name="unknown">Unknown</string>
-    <string name="copied">Copied to clipboard</string>
-    <string name="edit_lyrics">Edit lyrics</string>
-    <string name="search_lyrics">Search lyrics</string>
-    <string name="edit_song">Edit song</string>
-    <string name="song_title">Song title</string>
-    <string name="song_artists">Song artists</string>
-    <string name="error_song_title_empty">Song title cannot be empty.</string>
-    <string name="error_song_artist_empty">Song artist cannot be empty.</string>
-    <string name="save">Save</string>
-    <string name="choose_playlist">Choose playlist</string>
-    <string name="edit_playlist">Edit playlist</string>
-    <string name="create_playlist">Create playlist</string>
-    <string name="playlist_name">Playlist name</string>
-    <string name="error_playlist_name_empty">Playlist name cannot be empty.</string>
-    <string name="edit_artist">Edit artist</string>
-    <string name="artist_name">Artist name</string>
-    <string name="error_artist_name_empty">Artist name cannot be empty.</string>
-    <string name="duplicates">Duplicates</string>
-    <string name="skip_duplicates">Skip duplicates</string>
-    <string name="add_anyway">Add anyway</string>
-    <string name="duplicates_description_single">The song is already in your playlist</string>
-    <string name="duplicates_description_multiple">%d songs are already in your playlist</string>
-    <!-- Noun -->
-    <plurals name="n_song">
-        <item quantity="one">%d song</item>
-        <item quantity="other">%d songs</item>
-    </plurals>
-    <plurals name="n_artist">
-        <item quantity="one">%d artist</item>
-        <item quantity="other">%d artists</item>
-    </plurals>
-    <plurals name="n_album">
-        <item quantity="one">%d album</item>
-        <item quantity="other">%d albums</item>
-    </plurals>
-    <plurals name="n_playlist">
-        <item quantity="one">%d playlist</item>
-        <item quantity="other">%d playlists</item>
-    </plurals>
-    <plurals name="n_week">
-        <item quantity="one">%d week</item>
-        <item quantity="other">%d weeks</item>
-    </plurals>
-    <plurals name="n_month">
-        <item quantity="one">%d month</item>
-        <item quantity="other">%d months</item>
-    </plurals>
-    <plurals name="n_year">
-        <item quantity="one">%d year</item>
-        <item quantity="other">%d years</item>
-    </plurals>
-    <!-- Snackbar -->
-    <string name="added_to_playlist">Added to %s</string>
-    <string name="added_n_songs_to_playlist">Added %1$d songs to %2$s</string>
-    <string name="added_to_n_playlists">Added to %d playlists</string>
-    <string name="added_n_songs_to_n_playlists">Added %1$d songs to %2$d playlists</string>
-    <string name="playlist_imported">Playlist imported</string>
-    <string name="removed_song_from_playlist">Removed \"%s\" from playlist</string>
-    <string name="playlist_synced">Playlist synced</string>
-    <string name="undo">Undo</string>
-    <!-- Player -->
-    <string name="lyrics_not_found">Lyrics not found</string>
-    <string name="sleep_timer">Sleep timer</string>
-    <string name="end_of_song">End of song</string>
-    <plurals name="minute">
-        <item quantity="one">1 minute</item>
-        <item quantity="other">%d minutes</item>
-    </plurals>
-    <string name="error_no_stream">No stream available</string>
-    <string name="error_no_internet">No network connection</string>
-    <string name="error_timeout">Timeout</string>
-    <string name="error_unknown">Unknown error</string>
-    <!-- Player action -->
-    <string name="action_like">Like</string>
-    <string name="action_like_all">Like all</string>
-    <string name="action_remove_like">Remove like</string>
-    <string name="action_remove_like_all">Remove all likes</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-    <!-- Queue Title -->
-    <string name="queue_all_songs">All songs</string>
-    <string name="queue_searched_songs">Searched songs</string>
-    <string name="queue_continue_playing">Continue Playing</string>
-    <string name="queue_autoplaying_similar">Autoplaying similar music</string>
-    <!-- Notification name -->
-    <string name="music_player">Music Player</string>
-    <!-- Settings -->
-    <string name="settings">Settings</string>
-    <string name="appearance">Appearance</string>
-    <string name="theme">Theme</string>
-    <string name="enable_dynamic_theme">Enable dynamic theme</string>
-    <string name="random_theme_on_startup">Random theme on startup</string>
-    <string name="random_theme_on_startup_desc">Apply a random color palette every time the app starts</string>
-    <string name="use_system_font">Use system font</string>
-    <string name="use_system_font_desc">Use the device font instead of the app font</string>
-    <!-- Color Palette -->
-    <string name="color_palette">Color Palette</string>
-    <string name="customize_theme_colors">Choose your app theme colors</string>
-    <string name="selected_theme_color">Selected Theme Color</string>
-    <string name="theme_preview">Theme Preview</string>
-    <string name="select_palette">Select a color palette</string>
-    <string name="palette_applied">Palette applied</string>
-    <!-- Palette Names -->
-    <string name="palette_default">Default</string>
-    <!-- Blues -->
-    <string name="palette_ocean_blue">Ocean Blue</string>
-    <string name="palette_arctic_blue">Arctic</string>
-    <string name="palette_midnight_navy">Midnight</string>
-    <string name="palette_sky_blue">Sky Blue</string>
-    <string name="palette_cobalt_blue">Cobalt</string>
-    <string name="palette_electric_blue">Electric</string>
-    <!-- Greens -->
-    <string name="palette_emerald_green">Emerald</string>
-    <string name="palette_teal_wave">Teal Wave</string>
-    <string name="palette_forest_green">Forest</string>
-    <string name="palette_spotify_green">Spotify</string>
-    <string name="palette_mint_fresh">Mint</string>
-    <string name="palette_olive_garden">Olive</string>
-    <string name="palette_sage_green">Sage</string>
-    <!-- Oranges & Yellows -->
-    <string name="palette_sunset_orange">Sunset</string>
-    <string name="palette_golden_hour">Golden</string>
-    <string name="palette_warm_amber">Amber</string>
-    <string name="palette_tangerine_blast">Tangerine</string>
-    <string name="palette_peach">Peach</string>
-    <string name="palette_mango">Mango</string>
-    <!-- Purples -->
-    <string name="palette_royal_purple">Royal Purple</string>
-    <string name="palette_lavender_dream">Lavender</string>
-    <string name="palette_grape_purple">Grape</string>
-    <string name="palette_violet">Violet</string>
-    <string name="palette_amethyst">Amethyst</string>
-    <string name="palette_ultra_violet">Ultra Violet</string>
-    <!-- Pinks -->
-    <string name="palette_cherry_blossom">Sakura</string>
-    <string name="palette_rose_quartz">Rose Quartz</string>
-    <string name="palette_magenta_pop">Magenta</string>
-    <string name="palette_hot_pink">Hot Pink</string>
-    <string name="palette_blush">Blush</string>
-    <string name="palette_coral">Coral</string>
-    <string name="palette_bubblegum">Bubblegum</string>
-    <!-- Reds -->
-    <string name="palette_crimson_red">Crimson</string>
-    <string name="palette_youtube_red">YouTube</string>
-    <string name="palette_wine_red">Wine</string>
-    <string name="palette_ruby_red">Ruby</string>
-    <string name="palette_scarlet">Scarlet</string>
-    <!-- Neutrals -->
-    <string name="palette_charcoal">Charcoal</string>
-    <string name="palette_silver">Silver</string>
-    <string name="palette_slate">Slate</string>
-    <string name="palette_graphite">Graphite</string>
-    <!-- Earth Tones -->
-    <string name="palette_terracotta">Terracotta</string>
-    <string name="palette_coffee">Coffee</string>
-    <string name="palette_mocha">Mocha</string>
-    <string name="palette_sand">Sand</string>
-    <string name="palette_clay">Clay</string>
-    <!-- Pastels -->
-    <string name="palette_pastel_pink">Pastel Pink</string>
-    <string name="palette_pastel_blue">Pastel Blue</string>
-    <string name="palette_pastel_green">Pastel Green</string>
-    <string name="palette_pastel_yellow">Pastel Yellow</string>
-    <string name="palette_pastel_purple">Pastel Purple</string>
-    <!-- Neon & Vibrant -->
-    <string name="palette_neon_green">Neon Green</string>
-    <string name="palette_neon_pink">Neon Pink</string>
-    <string name="palette_neon_blue">Neon Blue</string>
-    <string name="palette_neon_orange">Neon Orange</string>
-    <string name="palette_cyberpunk">Cyberpunk</string>
-    <string name="palette_synthwave">Synthwave</string>
-    <!-- Special & Themed -->
-    <string name="palette_ocean">Ocean</string>
-    <string name="palette_forest">Deep Forest</string>
-    <string name="palette_autumn">Autumn</string>
-    <string name="palette_winter">Winter</string>
-    <string name="palette_spring">Spring</string>
-    <string name="palette_summer">Summer</string>
-    <string name="palette_twilight">Twilight</string>
-    <string name="palette_aurora">Aurora</string>
-    <string name="palette_candy">Candy</string>
-    <string name="palette_rainbow">Rainbow</string>
-    <!-- Additional Palettes -->
-    <string name="palette_aquamarine">Aquamarine</string>
-    <string name="palette_coral_reef">Coral Reef</string>
-    <string name="palette_cotton_candy">Cotton Candy</string>
-    <string name="palette_deep_sea">Deep Sea</string>
-    <string name="palette_electric_violet">Electric Violet</string>
-    <string name="palette_mustard">Mustard</string>
-    <string name="palette_olive">Olive</string>
-    <string name="palette_peachy_keen">Peachy Keen</string>
-    <string name="palette_plum">Plum</string>
-    <string name="palette_slate_gray">Slate Gray</string>
-    <string name="palette_sunset_beach">Sunset Beach</string>
-    <string name="palette_turquoise">Turquoise</string>
-    <!-- End of Color Palette -->
+    <string name="sleep_timer">स्लीप टाइमर</string>
+    <string name="action_like">पसंद करें</string>
+    <string name="action_like_all">सभी पसंद करें</string>
+    <string name="action_remove_like">पसंद हटाएं</string>
+    <string name="action_remove_like_all">सभी पसंद हटाएं</string>
+    <string name="action_shuffle_on">शफ़ल चालू</string>
+    <string name="action_shuffle_off">शफ़ल बंद</string>
+    <string name="repeat_mode_off">दोहराना बंद</string>
+    <string name="repeat_mode_one">वर्तमान गाना दोहराएं</string>
+    <string name="repeat_mode_all">कतार दोहराएं</string>
+    <string name="remove_from_queue">कतार से हटाएं</string>
+    <string name="skip_duplicates">डुप्लीकेट छोड़ें</string>
 
-    <string name="dark_theme">Dark theme</string>
-    <string name="dark_theme_on">On</string>
-    <string name="dark_theme_off">Off</string>
-    <string name="show_button">Show button</string>
-    <string name="corner_radius">Corner radius: %1$d</string>
-    <string name="adjust_radius">Adjust corner radius</string>
-    <string name="cancel_button">Cancel</string>
-    <string name="ok_button">OK</string>
-    <string name="custom_radius">Customize thumbnail corner radius</string>
-    <string name="custom">Custom</string>
-    <string name="customized_background">Customized background</string>
-    <string name="customize_background_title">Customize background</string>
-    <string name="add_image">Add image</string>
-    <string name="blur">Blur</string>
-    <string name="contrast">Contrast</string>
-    <string name="brightness">Brightness</string>
-    <string name="custom_value">Custom value</string>
-    <string name="new_library_design">New library design</string>
-    <string name="new_library_design_description">Enable the new library design (may be unstable)</string>
-    <string name="OpenTune_canvas">OpenTune Canvas</string>
-    <string name="OpenTune_canvas_desc">Animate album artwork while playing (Powered by BetterLyrics)</string>
-    <string name="show_button1_description">Toggle visibility of button 1 in Discord Rich Presence</string>
-    <string name="show_button2_description">Toggle visibility of button 2 in Discord Rich Presence</string>
-    <string name="discord_activity_type">Activity type</string>
-    <string name="dark_theme_follow_system">Follow system</string>
-    <string name="pure_black">Pure black</string>
-    <string name="disable_blur">Disable blur effects</string>
-    <string name="disable_blur_desc">Disable blur effects throughout the app</string>
-    <string name="customize_navigation_tabs">Customize navigation tabs</string>
-    <string name="player">Player</string>
-    <string name="player_text_alignment">Player text alignment</string>
-    <string name="lyrics_text_position">Lyrics text position</string>
-    <string name="sided">Sided</string>
-    <string name="left">Left</string>
-    <string name="center">Center</string>
-    <string name="right">Right</string>
-    <string name="player_slider_style">Player slider style</string>
-    <string name="slider_style_standard">Standard</string>
-    <string name="slider_style_wavy">Wavy</string>
-    <string name="slider_style_thick">Thick</string>
-    <string name="slider_style_circular">Circular</string>
-    <string name="slider_style_simple">Simple</string>
-    <string name="default_">Default</string>
-    <string name="squiggly">Squiggly</string>
-    <string name="misc">Misc</string>
-    <string name="default_open_tab">Default open tab</string>
-    <string name="grid_cell_size">Grid cell size</string>
-    <string name="small">Small</string>
-    <string name="big">Big</string>
-    <!-- Lyrics animation style -->
-    <string name="lyrics_animation_style">Lyrics animation style</string>
-    <!-- Animation options -->
-    <string name="none">None</string>
-    <string name="fade">Fade</string>
-    <string name="slide">Slide</string>
-    <string name="karaoke">Karaoke</string>
+    <!-- Queue -->
+    <string name="queue_all_songs">सभी गाने</string>
+    <string name="queue_searched_songs">खोजे गए गाने</string>
+    <string name="queue_continue_playing">चलाते रहें</string>
+    <string name="queue_autoplaying_similar">समान संगीत स्वचालित चला रहा है</string>
+
+    <!-- Lyrics -->
+    <string name="edit_lyrics">बोल संपादित करें</string>
+    <string name="search_lyrics">बोल खोजें</string>
+
+    <!-- Slider styles (new in 3.0.1) -->
+    <string name="player_slider_style">स्लाइडर शैली</string>
+    <string name="slider_style_standard">मानक</string>
+    <string name="slider_style_wavy">लहरदार</string>
+    <string name="slider_style_thick">मोटा</string>
+    <string name="slider_style_circular">गोलाकार</string>
+    <string name="slider_style_simple">सरल</string>
+    <string name="squiggly">टेढ़ा-मेढ़ा</string>
+    <string name="big">बड़ा</string>
+
+    <!-- Lyrics animation styles (new in 3.0.1) -->
+    <string name="karaoke">कराओके</string>
     <string name="apple_music_style">Apple Music</string>
-    <!-- Lyrics line spacing -->
-    <string name="lyrics_line_spacing">Lyrics line spacing</string>
-    <string name="content">Content</string>
-    <string name="action_logout">Log out</string>
-    <string name="action_login">Log in</string>
-    <string name="login">Login</string>
-    <string name="not_logged_in">Not logged in</string>
-    <string name="login_failed">Login failed</string>
-    <string name="playback_requires_youtube_music_confirmation">Confirm playback in YouTube Music, then return to OpenTune.</string>
-    <string name="content_language">Default content language</string>
-    <string name="content_country">Default content country</string>
-    <string name="system_default">System default</string>
-    <string name="enable_proxy">Enable proxy</string>
-    <string name="proxy_type">Proxy type</string>
-    <string name="proxy_url">Proxy URL</string>
-    <string name="stream_bypass_proxy">Bypass proxy for streams</string>
-    <string name="stream_bypass_proxy_desc">Use your direct IP for stream playback to avoid IP mismatch</string>
-    <string name="restart_to_take_effect">Restart to take effect</string>
-    <string name="enable_betterlyrics">Enable BetterLyrics</string>
-    <string name="enable_simpmusic_lyrics">Enable SimpMusic lyrics</string>
-    <string name="player_and_audio">Player and audio</string>
-    <string name="audio_quality">Audio quality</string>
-    <string name="audio_quality_auto">Auto</string>
-    <string name="audio_quality_high">High</string>
-    <string name="audio_quality_low">Low</string>
-    <string name="network_metered_title">Treat network as metered</string>
-    <string name="network_metered_description">When enabled, the app will prefer lower-quality streams on metered networks</string>
-    <string name="queue">Queue</string>
-    <string name="persistent_queue">Persistent queue</string>
-    <string name="persistent_queue_desc">Restore your last queue when the app starts</string>
-    <string name="permanent_shuffle">Permanent shuffle mode</string>
-    <string name="permanent_shuffle_desc">Keep shuffle enabled when you start a new song</string>
-    <string name="auto_load_more">Auto load more songs</string>
-    <string name="auto_load_more_desc">Automatically add more songs when the end of the queue is reached. Disabled when repeat mode is active</string>
-    <string name="skip_silence">Skip silence</string>
-    <string name="audio_normalization">Audio normalization</string>
-    <string name="audio_offload">Audio offload</string>
-    <string name="audio_offload_desc">Let supported devices play audio using low-power hardware decoding. Some audio processing features are disabled.</string>
-    <string name="pause_on_device_mute">Pause when device volume is 0</string>
-    <string name="pause_on_device_mute_desc">Automatically pause music when muted and resume when unmuted</string>
-    <string name="auto_skip_next_on_error">Auto skip to next song when error occurs</string>
-    <string name="auto_skip_next_on_error_desc">Ensure your continuous playback experience</string>
-    <string name="stop_music_on_task_clear">Stop music on task clear</string>
-    <string name="wakelock">Keep CPU awake during playback</string>
-    <string name="wakelock_desc">Prevents the system from interrupting music by holding a CPU wake lock</string>
-    <string name="auto_start_on_bluetooth">Auto-start on Bluetooth connect</string>
-    <string name="auto_start_on_bluetooth_desc">Automatically resume playback when a Bluetooth audio device connects</string>
-    <string name="artist_separators">Symbols to split artists</string>
-    <string name="artist_separators_desc">Symbols used to split multiple artists</string>
-    <string name="external_downloader">External Downloader</string>
-    <string name="external_downloader_desc">Download songs through an external app by package name</string>
-    <string name="external_downloader_package">Downloader App Package</string>
-    <string name="external_downloader_package_desc">Package name of the external downloader app (e.g. com.deniscerri.ytdl)</string>
-    <string name="open_with_downloader">Open with Downloader</string>
-    <string name="external_downloader_not_installed">External downloader app is not installed</string>
-    <string name="external_downloader_not_configured">No external downloader configured. Set one in Settings → Player.</string>
-    <string name="add_symbol">Add symbol</string>
-    <string name="enter_symbol">Enter symbol</string>
-    <string name="equalizer">Equalizer</string>
-    <string name="eq_waiting_for_audio_session">Waiting for audio session…</string>
-    <string name="eq_open_system_equalizer">Open system equalizer</string>
-    <string name="eq_presets">Presets</string>
-    <string name="eq_system">System</string>
-    <string name="eq_flat">Flat</string>
-    <string name="eq_profiles">Profiles</string>
-    <string name="eq_manage">Manage</string>
-    <string name="eq_system_preset">System preset</string>
-    <string name="eq_manual">Manual</string>
-    <string name="eq_profile_hint">Apply a profile or save your current settings</string>
-    <string name="eq_save">Save</string>
-    <string name="eq_save_profile">Save profile</string>
-    <string name="eq_profile_name">Profile name</string>
-    <string name="eq_custom_profile">Custom profile</string>
-    <string name="eq_import">Import</string>
-    <string name="eq_import_profiles">Import profiles</string>
-    <string name="eq_import_profiles_placeholder">Paste equalizer profiles JSON</string>
-    <string name="eq_import_failed">Invalid profile data</string>
-    <string name="eq_imported_profile">Imported</string>
-    <string name="eq_import_success">Imported %1$d profiles</string>
-    <string name="eq_bands">Bands</string>
-    <string name="eq_output_gain">Output gain</string>
-    <string name="eq_bass_boost">Bass boost</string>
-    <string name="eq_virtualizer">Virtualizer</string>
-    <string name="storage">Storage</string>
-    <string name="smart_trimmer">Smart Trimmer</string>
-    <string name="smart_trimmer_description">Smart trimmer dynamically manages the image cache and song cache, pruning old entries to save disk space.</string>
-    <string name="cache">Cache</string>
-    <string name="image_cache">Image Cache</string>
-    <string name="song_cache">Song Cache</string>
-    <string name="max_cache_size">Max cache size</string>
-    <string name="unlimited">Unlimited</string>
-    <string name="clear_all_downloads">Clear all downloads</string>
-    <string name="max_image_cache_size">Max image cache size</string>
-    <string name="clear_image_cache">Clear image cache</string>
-    <string name="max_song_cache_size">Max song cache size</string>
-    <string name="clear_song_cache">Clear song cache</string>
-    <string name="size_used">%s used</string>
-    <string name="privacy">Privacy</string>
-    <string name="listen_history">Listen history</string>
-    <string name="pause_listen_history">Pause listen history</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure you want to clear all listen history?</string>
-    <string name="search_history">Search history</string>
-    <string name="pause_search_history">Pause search history</string>
-    <string name="clear_search_history">Clear search history</string>
-    <string name="clear_search_history_confirm">Are you sure you want to clear all search history?</string>
-    <string name="use_login_for_browse">Use login for browsing content</string>
-    <string name="use_login_for_browse_desc">This can influence what content you see and for example shows premium-only albums if you are logged in with a Premium account</string>
-    <string name="disable_screenshot">Disable screenshot</string>
-    <string name="disable_screenshot_desc">When this option is on, screenshots and the app\'s view in Recents are disabled.</string>
-    <string name="enable_lrclib">Enable LrcLib lyrics provider</string>
-    <string name="enable_kugou">Enable KuGou lyrics provider</string>
-    <string name="preload_queue_lyrics">Preload queue lyrics</string>
-    <string name="queue_lyrics_preload_count">Number of songs to preload</string>
-    <string name="hide_explicit">Hide explicit content</string>
-    <string name="hide_video">Hide music videos</string>
-    <string name="backup_restore">Backup and restore</string>
-    <string name="action_backup">Backup</string>
-    <string name="action_restore">Restore</string>
-    <string name="imported_playlist">Imported playlist</string>
-    <string name="backup_create_success">Backup created successfully</string>
-    <string name="backup_create_failed">Couldn\'t create backup</string>
-    <string name="restore_success">Backup restored successfully</string>
-    <string name="restore_failed">Failed to restore backup</string>
-    <string name="discord_integration">Discord Integration</string>
-    <string name="discord_information">OpenTune uses the KizzyRPC library to set your Discord account\'s status. This involves using the Discord Gateway connection, which may be considered a violation of Discord\'s TOS. However, there are no known cases of user accounts being suspended for this reason. Use at your own risk.
-OpenTune will only extract your token, and everything else is stored locally.</string>
-    <string name="options">Options</string>
-    <string name="preview">Preview</string>
-    <string name="enable_discord_rpc">Enable Rich Presence</string>
-    <!-- Last.fm -->
-    <string name="scrobbling">Scrobbling</string>
-    <string name="lastfm_integration">Last.fm Integration</string>
-    <string name="enable_scrobbling">Enable Scrobbling</string>
-    <string name="lastfm_now_playing">Update Now Playing</string>
-    <string name="scrobbling_configuration">Scrobbling Configuration</string>
-    <string name="scrobble_min_track_duration">Minimum Track Duration</string>
-    <string name="scrobble_delay_percent">Scrobble Delay Percent</string>
-    <string name="scrobble_delay_minutes">Scrobble Delay (Seconds)</string>
-    <string name="username">Username</string>
-    <string name="password">Password</string>
-    <string name="logging_in">Logging in…</string>
-    <!-- ListenBrainz -->
-    <string name="listenbrainz_scrobbling">ListenBrainz scrobbling</string>
-    <string name="listenbrainz_scrobbling_description">Enable submitting now-playing and finished listens to ListenBrainz</string>
-    <string name="set_listenbrainz_token">Set ListenBrainz token</string>
-    <string name="edit_listenbrainz_token">Edit ListenBrainz token</string>
-    <!-- Discord activity customization -->
-    <string name="discord_activity_name">Activity name</string>
-    <string name="discord_activity_details">Activity details</string>
-    <string name="discord_activity_state">Activity state</string>
-    <string name="discord_activity_button_1_url">Button 1 URL Source</string>
-    <string name="discord_activity_button_2_url">Button 2 URL Source</string>
-    <string name="discord_activity_button1_label">Button 1 label</string>
-    <string name="discord_activity_button1_url">Button 1 Custom URL</string>
-    <string name="discord_activity_button2_label">Button 2 label</string>
-    <string name="discord_activity_button2_url">Button 2 Custom URL</string>
-    <string name="large_image_custom_url">Large image custom URL</string>
-    <string name="large_image">Large Image</string>
-    <string name="large_text">Large Text</string>
-    <string name="custom_large_text">Custom Large Text</string>
-    <string name="small_image">Small Image</string>
-    <string name="small_image_custom_url">Small image custom URL</string>
-    <string name="activity_status">Activity Status</string>
-    <string name="platform_status">Platform</string>
-    <string name="update_interval">Presence Update Interval</string>
-    <!--Discord Tranalstor Settings-->
-    <string name="translator_options">Translator Options</string>
-    <string name="enable_translator">Enable Translator</string>
-    <string name="enable_translator_desc">Translate selected fields before sending to Discord RPC</string>
-    <string name="context_info">Contexts (comma-separated)</string>
-    <string name="translator_info_usage">Use Example: {song}, {artist}, {album}</string>
-    <string name="target_language">Target Language</string>
-    <string name="select_language">Select Language</string>
-    <string name="close_dialog">Close</string>
-    <string name="select_dialog">Select</string>
-    <string name="support_github">Star OpenTune!</string>
-    <!-- Update dialog -->
-    <string name="new_update_available">New update available</string>
-    <string name="release_notes_unavailable">Release notes are unavailable</string>
-    <string name="update_text">Update</string>
-    <!-- Translate UI strings -->
-    <string name="translate">Translate</string>
-    <string name="language_label">Language</string>
-    <string name="lyrics">Lyrics</string>
-    <string name="translation_success">Translation saved</string>
-    <string name="translation_failed">Translation failed</string>
-    <!-- Discord settings additions -->
-    <string name="discord_button_options">Button Options</string>
-    <string name="discord_image_options">Image Options</string>
-    <string name="refresh">Refresh</string>
-    <string name="description_refresh">Manually refresh Discord Rich Presence</string>
-    <string name="discord_show_when_paused">Show RPC when paused</string>
-    <string name="discord_show_when_paused_desc">If enabled, Rich Presence will remain visible while paused with a pause icon. If disabled, RPC will disappear when paused.</string>
-    <string name="discord_paused">Paused</string>
-    <string name="show_small_image">Show small image</string>
-    <string name="description_show_small_image">When enabled, a small circular image is shown in the Rich Presence preview and sent to Discord if available</string>
-    <string name="logout_confirm_title">Confirm logout</string>
-    <string name="logout_confirm_message">Are you sure you want to log out of Discord?.</string>
-    <string name="logout_confirm_yes">Log out</string>
-    <string name="logout_confirm_no">Cancel</string>
-    <!--Misc settings additions-->
-    <string name="experiment_settings">Experimental Settings</string>
-    <string name="show_discord_debug_ui">Show Debug UI</string>
-    <string name="enable_discord_debug_lines">Enable debug settings lines</string>
-    <string name="presence_manager_running">Presence manager: running</string>
-    <string name="presence_manager_stopped">Presence manager: stopped</string>
-    <string name="filter_levels">Filter levels</string>
-    <string name="experimental_features">Experimental Features</string>
-    <string name="experimental_features_description">Advanced or experimental Discord options (moved to separate screen)</string>
-    <string name="experimental_feature">Experimental Feature</string>
-    <string name="open">Open</string>
-    <string name="reset_to_default_levels">Reset to default</string>
-    <string name="no_logs">No Logs</string>
-    <string name="show_nerd_stats">Show nerd stats</string>
-    <string name="description_show_nerd_stats">Display real-time playback statistics (codec, bitrate, buffer)</string>
-    <string name="display_codec_on_player">Display Codec on Player</string>
-    <string name="description_display_codec_on_player">Show current audio codec information on the player</string>
-    <string name="nerd_stats">Nerd Stats</string>
-    <string name="track_label">Track</string>
-    <string name="no_track_playing">No track playing</string>
-    <string name="codec_label">Codec</string>
-    <string name="unknown_codec">Unknown codec</string>
-    <string name="bitrate_label">Bitrate</string>
-    <string name="unknown_bitrate">Unknown bitrate</string>
-    <string name="sample_rate_label">Sample Rate</string>
-    <string name="unknown_sample_rate">Unknown sample rate</string>
-    <string name="content_length_label">Content Length</string>
-    <string name="unknown_content_length">Unknown content length</string>
-    <string name="format_label">Format</string>
-    <string name="loading_format">Loading format…</string>
-    <string name="buffer_health_label">Buffer Health</string>
-    <string name="playback_speed_label">Playback Speed</string>
-    <string name="state_label">State</string>
-    <string name="media_id_label">Media ID</string>
-    <string name="status_active">ACTIVE</string>
-    <string name="status_inactive">INACTIVE</string>
-    <string name="last_start">Last Start</string>
-    <string name="last_end">Last End</string>
-    <string name="debug_logs">Debug Logs</string>
-    <string name="log_level_verbose">Verbose</string>
-    <string name="log_level_debug">Debug</string>
-    <string name="log_level_info">Info</string>
-    <string name="log_level_warning">Warning</string>
-    <string name="log_level_error">Error</string>
-    <string name="filter_discord_only">Discord</string>
-    <string name="filter_all_logs">All</string>
-    <string name="clear">Clear</string>
-    <string name="logs_empty_message">Logs will appear here when available</string>
-    <string name="real_time_playback_stats">Real-time playback statistics</string>
-    <string name="copied_to_clipboard">Copied log to clipboard</string>
-    <string name="playback_state_idle">IDLE</string>
-    <string name="playback_state_buffering">BUFFERING</string>
-    <string name="playback_state_ready">READY</string>
-    <string name="playback_state_ended">ENDED</string>
-    <string name="playback_state_unknown">UNKNOWN</string>
-    <string name="share_logs">Share logs</string>
-    <string name="about">About</string>
-    <string name="app_version">App version</string>
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
-    <string name="updates">Updates</string>
-    <string name="current_version">Current Version</string>
-    <string name="latest_version_format">Latest: %s</string>
-    <string name="notification_settings">Notification</string>
-    <string name="enable_update_notification">Enable Update Notification</string>
-    <string name="enable_update_notification_desc">Get notified when a new stable version is released</string>
-    <string name="update_channel">Update Channel</string>
-    <string name="channel_stable">Stable</string>
-    <string name="channel_nightly">Nightly</string>
-    <string name="commit_history">Development</string>
-    <string name="recent_commits">Recent Commits</string>
-    <string name="changelog">Changelog</string>
-    <string name="view_changelog">View Changelog</string>
-    <string name="error_loading_changelog">Error loading changelog</string>
-    <string name="no_releases">No releases found</string>
-    <string name="update_notification_channel_name">App Updates</string>
-    <string name="update_notification_channel_desc">Notifications for new app updates</string>
-    <string name="update_notification_title">Update Available</string>
-    <string name="update_notification_text">OpenTune %s is now available</string>
-    <string name="download">Download</string>
+    <string name="fade">फ़ेड</string>
+    <string name="slide">स्लाइड</string>
 
-    <string name="permissions_title">Allow OpenTune to work best</string>
-    <string name="permissions_subtitle">We use a few permissions to play and manage your music reliably. You can change these anytime in system settings.</string>
-    <string name="permission_storage_title">Storage access</string>
-    <string name="permission_storage_desc">Required to read your downloaded and local audio files for playback.</string>
-    <string name="permission_notifications_title">Notifications</string>
-    <string name="permission_notifications_desc">Used to show playback controls and keep music running in the background.</string>
-    <string name="permission_status_allowed">Allowed</string>
-    <string name="permission_status_all_granted">All required permissions are allowed. You are ready to start.</string>
-    <string name="permission_status_required">Please allow all required permissions to continue.</string>
-    <string name="next">Next</string>
-    <string name="next_song">Next Song</string>
-    <string name="allow">Allow</string>
-    <!-- Playlist Suggestions -->
-    <string name="you_might_like">You might like</string>
-    <string name="refresh_suggestions">Refresh suggestions</string>
+    <!-- Speed dial -->
+    <string name="speed_dial">स्पीड डायल</string>
+    <string name="speed_dial_random">यादृच्छिक स्पीड डायल गाना चलाएं</string>
+    <string name="pin_to_speed_dial">स्पीड डायल में पिन करें</string>
+    <string name="remove_from_speed_dial">स्पीड डायल से हटाएं</string>
 
-    <string name="music_together">OpenTune Music Together</string>
-    <string name="together_display_name">Display name</string>
-    <string name="together_display_name_placeholder">Your name</string>
-    <string name="together_port">Session port</string>
-    <string name="together_allow_guests_add">Guests can add songs</string>
-    <string name="together_allow_guests_control">Guests can control playback</string>
-    <string name="together_require_approval">Require approval</string>
-    <string name="together_lan">LAN</string>
-    <string name="together_online">Online</string>
-    <string name="together_join_link">Link</string>
-    <string name="together_join_code">Code</string>
-    <string name="together_join_link_hint">Paste a join link or code</string>
-    <string name="together_join_code_hint">Enter a session code</string>
-    <string name="start_session">Start session</string>
-    <string name="end_session">End session</string>
-    <string name="join_session">Join session</string>
-    <string name="session_link">Session link</string>
-    <string name="session_code">Session code</string>
-    <string name="participants">Participants</string>
-    <string name="pending_requests">Join requests</string>
-    <string name="waiting_for_approval">Waiting for approval</string>
-    <string name="host">Host</string>
-    <string name="session_settings">Session settings</string>
-    <string name="add_current_song">Add current song</string>
-    <string name="playback_controls">Playback controls</string>
-    <string name="approve">Approve</string>
-    <string name="deny">Deny</string>
-    <string name="dismiss">Dismiss</string>
-    <string name="enabled">Enabled</string>
-    <string name="disabled">Disabled</string>
-    <string name="invalid_link">Invalid link</string>
-    <string name="invalid_code">Invalid code</string>
-    <string name="not_allowed">Not allowed</string>
-    <string name="network_unavailable">Network unavailable</string>
-    <string name="together_online_not_configured">Online sessions aren\'t configured</string>
-    <string name="together_token_missing">Online sessions aren\'t available in this build</string>
-    <string name="together_server_unreachable">Server unreachable</string>
-    <string name="together_connection_timed_out">Connection timed out</string>
-    <string name="together_session_not_found">Session not found</string>
-    <string name="together_server_error">Server error, please try again later</string>
-    <string name="leave">Leave</string>
-    <string name="join">Join</string>
-    <string name="joined">Joined</string>
-    <string name="loading">Loading</string>
-    <string name="connecting">Connecting…</string>
-    <string name="copy_link">Copy link</string>
+    <!-- Music Together -->
+    <string name="together_participants">प्रतिभागी</string>
+    <string name="together_role_host">होस्ट</string>
+    <string name="together_role_guest">अतिथि</string>
+    <string name="together_pending_approval">अनुमोदन प्रतीक्षित</string>
+    <string name="together_waiting_approval">अनुमोदन की प्रतीक्षा में</string>
+    <string name="together_host_left_session">होस्ट ने सत्र छोड़ा</string>
+    <string name="together_kick">निकालें</string>
+    <string name="together_ban">प्रतिबंधित करें</string>
+    <string name="together_requesting_song_change">होस्ट से गाना बदलने का अनुरोध…</string>
+    <string name="together_song_change_failed">गाना नहीं बदला। कृपया पुन: प्रयास करें।</string>
 
-    <string name="together_host_section">Host</string>
-    <string name="together_join_section">Join</string>
-    <string name="together_status">Status</string>
-    <string name="together_idle">Not in a session</string>
-    <string name="together_hosting">Hosting session</string>
-    <string name="together_joining">Joining session</string>
-    <string name="together_connected">Connected</string>
-    <string name="together_error_state">Error</string>
+    <!-- Sync -->
+    <string name="action_sync">सिंक</string>
+    <string name="select_playlist_to_sync">सिंक के लिए प्लेलिस्ट चुनें</string>
+    <string name="playlist_synced">प्लेलिस्ट सिंक हुई</string>
 
-    <string name="got_it">Got it</string>
-    <string name="together_dont_show_again">Don\'t show this again</string>
-    <string name="together_welcome_title">Welcome to OpenTune Music Together</string>
-    <string name="together_welcome_body">Music Together lets multiple devices share a live session with a synced queue and playback.</string>
-    <string name="together_welcome_host_title">Host a session</string>
-    <string name="together_welcome_host_body">Tap Start session, then share the session link. Keep OpenTune open in the background while hosting.</string>
-    <string name="together_welcome_join_title">Join from another device</string>
-    <string name="together_welcome_join_body">Open the shared link, or enter code and tap Join. Your queue and playback will follow the host.</string>
-    <string name="together_welcome_permissions_title">Permissions and safety</string>
-    <string name="together_welcome_permissions_body">Hosts can decide whether guests can add songs, control playback, or require approval to join.</string>
+    <!-- Backup and restore -->
+    <string name="action_backup">बैकअप</string>
+    <string name="action_restore">पुनर्स्थापित करें</string>
 
-    <string name="po_token_generation">PO Token Generation</string>
-    <string name="po_token_generation_subtitle">Generate and manage web client PO tokens</string>
-    <string name="web_client_po_token">Web Client PO Token</string>
-    <string name="web_client_po_token_desc">Enable PO token generation for web-based player clients</string>
-    <string name="po_token_gvs">PO Token (GVS)</string>
-    <string name="po_token_player">PO Token (Player)</string>
-    <string name="visitor_data">Visitor Data</string>
-    <string name="supported_clients">Supported Clients</string>
-    <string name="generated_tokens">Generated Tokens</string>
-    <string name="token_settings">Token Settings</string>
-    <string name="use_visitor_data">Use Visitor Data</string>
-    <string name="use_visitor_data_desc">Use visitor data for token generation. Requires cookies to be disabled.</string>
-    <string name="cookies_must_be_disabled">Cookies must be disabled to use visitor data</string>
-    <string name="regenerate">Re-generate</string>
-    <string name="regenerate_token">Regenerate Token</string>
-    <string name="regenerate_desc">Refresh all tokens</string>
-    <string name="source_url">Source URL</string>
-    <string name="source_url_placeholder">https://youtube.com/account</string>
-    <string name="generating_tokens">Generating tokens…</string>
-    <string name="tokens_generated">Tokens generated successfully</string>
-    <string name="token_generation_failed">Token generation failed</string>
-    <string name="open_account_before_extract">Open and sign in on youtube.com/account before extracting</string>
-    <string name="token_copied">Token copied to clipboard</string>
-    <string name="no_visitor_data">No visitor data available. Tokens cannot be generated.</string>
-    <string name="extracting_from_url">Extracting tokens from URL…</string>
-    <string name="contributors">Contributors</string>
+    <!-- Account -->
+    <string name="login">लॉगिन</string>
+    <string name="action_login">लॉग इन करें</string>
+    <string name="action_logout">लॉग आउट करें</string>
+    <string name="music_recognition">संगीत पहचान</string>
 
+    <!-- Appearance settings -->
+    <string name="appearance">रूप-रंग</string>
+    <string name="player_text_alignment">प्लेयर टेक्स्ट संरेखण</string>
+    <string name="right">दाईं ओर</string>
+    <string name="blur">धुंधला</string>
+    <string name="brightness">चमक</string>
+    <string name="disable_blur">धुंधला प्रभाव बंद करें</string>
+    <string name="disable_blur_desc">पूरे ऐप में धुंधला प्रभाव बंद करें</string>
+    <string name="customized_background">अनुकूलित पृष्ठभूमि</string>
+    <string name="customize_background_title">पृष्ठभूमि अनुकूलित करें</string>
+    <string name="random_theme_on_startup">शुरुआत में यादृच्छिक थीम</string>
+    <string name="random_theme_on_startup_desc">हर बार ऐप शुरू होने पर यादृच्छिक रंग पैलेट लागू करें</string>
+    <string name="OpenTune_canvas">OpenTune Canvas</string>
 
-    <!-- Troubleshooter -->
-    <string name="troubleshooter">Troubleshooter</string>
-    <string name="troubleshooter_desc">Clears the song cache and resets expired Visitor Data to resolve playback errors.</string>
-    <string name="troubleshooter_confirm_desc">Temporary song cache will be cleared and Visitor Data reset. Downloads and library will not be affected.</string>
-    <string name="troubleshooter_run">Run troubleshooter</string>
-    <string name="troubleshooter_running">Applying fixes…</string>
-    <string name="troubleshooter_done">Fixes successfully applied. Restart the app if the problem persists.</string>
-    <string name="confirm">Confirm</string>
-    <string name="social_links">Social Networks</string>
-    <string name="view_license">View full license on GitHub</string>
-    <string name="paste">Paste</string>
-    <string name="player_design_v7">Immersive</string>
-    <string name="liquid_glass_navbar">Liquid Glass Navbar</string>
+    <!-- Filters -->
+    <string name="filter_bookmarked">बुकमार्क किए गए</string>
+    <string name="other_versions">अन्य संस्करण</string>
+    <string name="advanced">उन्नत</string>
 
+    <!-- Errors -->
+    <string name="error_no_stream">कोई स्ट्रीम उपलब्ध नहीं</string>
+    <string name="error_no_internet">कोई नेटवर्क कनेक्शन नहीं</string>
+    <string name="error_timeout">समय समाप्त</string>
+    <string name="error_unknown">अज्ञात त्रुटि</string>
+    <string name="error_song_title_empty">गाने का शीर्षक खाली नहीं हो सकता।</string>
+    <string name="error_song_artist_empty">गाने का कलाकार खाली नहीं हो सकता।</string>
+    <string name="error_playlist_name_empty">प्लेलिस्ट का नाम खाली नहीं हो सकता।</string>
+    <string name="error_artist_name_empty">कलाकार का नाम खाली नहीं हो सकता।</string>
+
+    <!-- Common buttons -->
+    <string name="cancel_button">रद्द करें</string>
+    <string name="ok_button">ठीक है</string>
+    <string name="got_it">समझ गया</string>
+    <string name="update_button">अपडेट</string>
+    <string name="support_github">OpenTune को स्टार दें!</string>
+
+    <!-- New in 3.0.1 -->
+    <string name="liquid_glass_navbar">लिक्विड ग्लास नेवबार</string>
+
+    <!-- Local Music Screen -->
+    <string name="local_music">लोकल म्यूज़िक</string>
+    <string name="local_music_subtitle">डिवाइस पर संग्रहीत संगीत चलाएं</string>
+    <string name="local_music_scanning">डिवाइस संगीत स्कैन हो रहा है…</string>
+    <string name="local_music_empty">कोई संगीत नहीं मिला</string>
+    <string name="local_music_empty_desc">यहाँ देखने के लिए अपने डिवाइस स्टोरेज में ऑडियो फ़ाइलें जोड़ें</string>
+    <string name="local_music_permission_title">स्टोरेज एक्सेस आवश्यक है</string>
+    <string name="local_music_permission_desc">OpenTune को आपके डिवाइस से ऑडियो फ़ाइलें पढ़ने के लिए अनुमति चाहिए।</string>
+    <string name="local_music_grant_permission">अनुमति दें</string>
 </resources>


### PR DESCRIPTION
## हिन्दी अनुवाद विस्तार | Hindi Translation Expansion

Expands the existing Hindi translation (values-hi/strings.xml)
from the initial 30 strings (merged in #536) to a complete 159
string translation covering all current app features.

### What's added

**3.0.1 Player features**
- PlayerSlider styles (wavy, thick, circular, squiggly, simple)
- Lyrics animation modes (karaoke, Apple Music, fade, slide)
- Sleep timer, tempo & pitch, volume controls
- Repeat modes, shuffle on/off actions

**Music Together**
- Session roles (host, guest)
- Approval flow strings
- Kick, ban, song change request messages

**Library & Queue**
- Queue actions (continue playing, autoplaying similar)
- Speed dial (pin, remove, random play)
- Sync, skip duplicates, playlist synced

**Appearance & Settings**
- Liquid Glass Navbar (new in 3.0.1)
- Blur, brightness, background customization
- Random theme on startup
- Player text alignment

**Errors & Common UI**
- Network, timeout, stream errors
- Validation errors (empty title, artist, playlist name)
- Cancel, OK, Got it, Update buttons

**Local Music Screen**
- All 8 strings for the new local device music feature

### Notes
- All translations reviewed for natural Hindi phrasing
- Technical terms (Canvas, Apple Music, Discord) kept in original
- Contributor: @Gorupa 